### PR TITLE
Escape underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $> /usr/local/mapzen/whosonfirst-placetypes/bin/compile.py | python -mjson.tool
 }
 ```
 
-The specification itself is hardcoded in [mapzen/whosonfirst/placetypes/__init__.py](https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/blob/master/mapzen/whosonfirst/placetypes/__init__.py). Whether or the specification can or should be loaded from a config file or equivalent has been left for another day.
+The specification itself is hardcoded in [mapzen/whosonfirst/placetypes/\__init__.py](https://github.com/whosonfirst/py-mapzen-whosonfirst-placetypes/blob/master/mapzen/whosonfirst/placetypes/__init__.py). Whether or the specification can or should be loaded from a config file or equivalent has been left for another day.
 
 ## See also
 


### PR DESCRIPTION
So it's "**init**" instead of a bold "init".
